### PR TITLE
feat: API to serve VideoMetaData for Video On Demand Streaming through CDN 

### DIFF
--- a/src/core_apps/event_manager/models.py
+++ b/src/core_apps/event_manager/models.py
@@ -107,7 +107,7 @@ class Subtitle(models.Model):
         VideoMetaData, on_delete=models.CASCADE, related_name="subtitles"
     )
     language = models.CharField(max_length=6)
-    content = JSONField()  
+    content = models.TextField()
 
     def __str__(self):
         return f"{self.video.title} - {self.language}"

--- a/src/core_apps/event_manager/serializers.py
+++ b/src/core_apps/event_manager/serializers.py
@@ -1,11 +1,11 @@
 from rest_framework import serializers
 
-from core_apps.event_manager.models import VideoMetaData
+from core_apps.event_manager.models import VideoMetaData, Subtitle
 
 
-class VideoMetaDataSerializer(serializers.ModelSerializer):
-    """Serializer for the VideoMetaData model."""
-    
+class VideoMetaDataPOSTSerializer(serializers.ModelSerializer):
+    """Serializer for the VideoMetaData model to Create an Instance."""
+
     class Meta:
         model = VideoMetaData
         fields = [
@@ -17,3 +17,5 @@ class VideoMetaDataSerializer(serializers.ModelSerializer):
             "email", 
             "phone_number", 
         ]
+
+

--- a/src/core_apps/event_manager/views.py
+++ b/src/core_apps/event_manager/views.py
@@ -18,13 +18,12 @@ from celery import chain
 
 from core_apps.event_manager.utils import save_video_local_storage
 from core_apps.event_manager.models import VideoMetaData
-from core_apps.event_manager.serializers import VideoMetaDataSerializer
+from core_apps.event_manager.serializers import VideoMetaDataPOSTSerializer
 from core_apps.event_manager.tasks import (
     upload_video_to_s3,
     delete_local_video_file_after_s3_upload,
     publish_s3_metadata_to_mq,
 )
-
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +79,7 @@ class VideoUploadAPIView(APIView):
 
             s3_file_key = f"{settings.MOVIO_S3_VIDEO_ROOT}/{video_filename_without_extention}/{video_file_extention_without_dot}/{video_filename_with_extention}"
 
-            serializer = VideoMetaDataSerializer(data=db_data)
+            serializer = VideoMetaDataPOSTSerializer(data=db_data)
 
             if serializer.is_valid(raise_exception=True):
                 video_metadata = serializer.save()
@@ -173,12 +172,10 @@ class VideoUploadAPIView(APIView):
             - video_extention (str): video extention
         """
 
-        # Authentication and Request Body validations are mapped in two separate middleware. See Middlesares for more details.
+        # NOTE: Authentication and Request Body validations are mapped in two separate middleware. See Middlesares for more details.
 
         video_file_size = request.video_file_size
         video_file_content_type = request.video_file_content_type
-
-        print("content type: ", video_file_content_type)
 
         # save video in tmp file for furthur processing
         result = self.process_video_for_local_storage(request=request)
@@ -190,3 +187,5 @@ class VideoUploadAPIView(APIView):
             video_file_size=video_file_size,
             video_file_content_type=video_file_content_type,
         )
+
+

--- a/src/core_apps/stream/paginations.py
+++ b/src/core_apps/stream/paginations.py
@@ -1,0 +1,9 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class VideoMetaDataPageNumberPagination(PageNumberPagination):
+    """Pagination class for core_apps.video_upload.models.VideoMetaData"""
+
+    page_size = 10
+    page_query_param = "page"
+    max_page_size = 25

--- a/src/core_apps/stream/renderers.py
+++ b/src/core_apps/stream/renderers.py
@@ -1,0 +1,45 @@
+import json
+
+from rest_framework.renderers import JSONRenderer
+
+
+class VideoMetaDataJSONRenderer(JSONRenderer):
+    """Defalut renderer class for single VideoMetadata or Subtitele object."""
+
+    charset = "utf-8"
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        if renderer_context is None:
+            status_code = 200
+        else:
+            status_code = renderer_context.get("response").status_code
+
+        if data is not None:
+            errors = data.get("errors", None)
+        else:
+            errors = None
+
+        if errors is not None:
+            return super(VideoMetaDataJSONRenderer, self).render(data)
+        else:
+            return json.dumps({"status_code": status_code, "video": data})
+
+
+class VideosMetadataJSONRenderer(JSONRenderer):
+    """Defalut Renderer class for VideoMetadata Queryset"""
+
+    charset = "utf-8"
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        if renderer_context is None:
+            status_code = 200
+        else:
+            status_code = renderer_context.get("response").status_code
+
+        errors = data.get("errors", None)
+
+        # if there are errors, then render as per default JSON style. Pass if errors is None
+        if errors is not None:
+            return super(VideosMetadataJSONRenderer, self).render(data)
+        else:
+            return json.dumps({"status_code": status_code, "videos": data})

--- a/src/core_apps/stream/serializers.py
+++ b/src/core_apps/stream/serializers.py
@@ -1,0 +1,29 @@
+from rest_framework import serializers
+
+from core_apps.event_manager.models import VideoMetaData, Subtitle
+
+
+class SubtitleSerializer(serializers.ModelSerializer):
+    """Serializer for the Subtitle model"""
+
+    class Meta:
+        model = Subtitle
+        fields = ["language", "content"]
+
+
+class VideoMetaDataGETSerializer(serializers.ModelSerializer):
+    """Serializer for the VideoMetaData model to Get Video Information"""
+
+    subtitles = SubtitleSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = VideoMetaData
+        fields = [
+            "custom_video_title",
+            "title",
+            "description",
+            "duration",
+            "mp4_s3_mpd_url",
+            "mp4_gcore_cdn_mpd_url",
+            "subtitles",
+        ]

--- a/src/core_apps/stream/urls.py
+++ b/src/core_apps/stream/urls.py
@@ -1,5 +1,7 @@
 from django.urls import path
 
+from core_apps.stream.views import GetVideoMetadataAPIView
+
 urlpatterns = [
-        
+        path("video/<uuid:video_id>/", GetVideoMetadataAPIView.as_view(), name="get_video_metadata"),
 ]

--- a/src/core_apps/stream/views.py
+++ b/src/core_apps/stream/views.py
@@ -1,3 +1,35 @@
-from django.shortcuts import render
+from uuid import UUID
+from django.http import HttpRequest
 
-# Create your views here.
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import AllowAny
+from rest_framework import status
+
+
+from core_apps.event_manager.models import VideoMetaData
+from core_apps.stream.renderers import VideoMetaDataJSONRenderer
+from core_apps.stream.serializers import VideoMetaDataGETSerializer
+from core_apps.stream.paginations import VideoMetaDataPageNumberPagination # noqa 
+
+
+class GetVideoMetadataAPIView(APIView):
+    """API View to retrieeve video metadata along with subtitles"""
+
+    permission_classes = [AllowAny]
+    renderer_classes = [VideoMetaDataJSONRenderer]
+    
+
+    def get(self, request: HttpRequest, video_id: UUID, format=None) -> Response:
+        try:
+            video_meatadata = VideoMetaData.objects.get(id=video_id)
+        except VideoMetaData.DoesNotExist:
+            return Response(
+                {"status": "error", "detail": "Video not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        serializer = VideoMetaDataGETSerializer(video_meatadata)
+        return Response(
+            {"status": "success", "detail": serializer.data}, status=status.HTTP_200_OK
+        )

--- a/src/html-templates/dash-plyaer-api.html
+++ b/src/html-templates/dash-plyaer-api.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Movio Player</title>
+    <script src="https://cdn.dashjs.org/latest/dash.all.min.js"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
+    />
+    <style>
+      body {
+        font-family: "Nunito Sans", sans-serif;
+        background-color: #d9dfe4;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+
+      .header {
+        width: 100%;
+        background-color: #16bdb4;
+        color: white;
+        padding: 10px 0;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 10px 20px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+      }
+
+      .header .logo {
+        font-size: 24px;
+        font-weight: bold;
+      }
+
+      .header .menu {
+        display: flex;
+        gap: 15px;
+      }
+
+      .header .menu a {
+        color: white;
+        text-decoration: none;
+        font-size: 18px;
+      }
+
+      .header .menu a:hover {
+        text-decoration: underline;
+      }
+
+      .container {
+        max-width: 1200px;
+        margin: 20px auto;
+        padding: 20px;
+        background-color: white;
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        width: 100%;
+        box-sizing: border-box;
+      }
+
+      .video-container {
+        position: relative;
+        padding-bottom: 56.25%;
+        /* 16:9 aspect ratio */
+        height: 0;
+        overflow: hidden;
+      }
+
+      .video-container video {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      .title {
+        font-size: 24px;
+        font-weight: bold;
+        margin: 10px 0;
+      }
+
+      .description {
+        font-size: 14px;
+        color: #606060;
+      }
+
+      .comments-section {
+        margin-top: 30px;
+      }
+
+      .comment {
+        margin-bottom: 20px;
+      }
+
+      .comment-author {
+        font-weight: bold;
+        margin-right: 5px;
+      }
+
+      .comment-text {
+        color: #333;
+      }
+
+      .add-comment {
+        margin-top: 20px;
+      }
+
+      .add-comment textarea {
+        width: 100%;
+        padding: 10px;
+        margin-bottom: 10px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        resize: vertical;
+      }
+
+      .add-comment button {
+        background-color: #16bdb4;
+        color: white;
+        padding: 10px 20px;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+      }
+
+      @media (max-width: 768px) {
+        .header .logo {
+          font-size: 20px;
+        }
+
+        .header .menu a {
+          font-size: 16px;
+        }
+
+        .title {
+          font-size: 20px;
+        }
+
+        .description {
+          font-size: 12px;
+        }
+      }
+
+      @media (max-width: 480px) {
+        .header {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .header .menu {
+          flex-direction: column;
+          gap: 10px;
+          align-items: flex-start;
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="header">
+      <div class="logo"><i class="fas fa-play-circle"></i> Movio Player</div>
+      <div class="menu">
+        <a href="#"><i class="fas fa-home"></i> Home</a>
+        <a href="#"><i class="fas fa-video"></i> Videos</a>
+        <a href="#"><i class="fas fa-user"></i> Profile</a>
+      </div>
+    </div>
+    <div class="container">
+      <div class="video-container">
+        <video id="videoPlayer" controls></video>
+      </div>
+      <div class="title">Popeyen The President</div>
+      <div class="description">Nostalgia Vintage Popeye Cartoon :p</div>
+      <div class="comments-section">
+        <div class="comment">
+          <span class="comment-author">Yurious:</span>
+          <span class="comment-text"
+            >I love popeye cartoon man! Thanks for sharing.</span
+          >
+        </div>
+        <div class="comment">
+          <span class="comment-author">Mehboob:</span>
+          <span class="comment-text"
+            >Very nostalgic, upload more such video!</span
+          >
+        </div>
+        <div class="comment">
+          <span class="comment-author">Angel Priya:</span>
+          <span class="comment-text"
+            >Really very good animation! Old is Gold!</span
+          >
+        </div>
+        <div class="add-comment">
+          <textarea placeholder="Add a public comment..."></textarea>
+          <button type="button">Comment</button>
+        </div>
+      </div>
+    </div>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        const videoId = "43723366-b4e9-4afb-a7f1-50d102509376";
+
+        function getOS() {
+          const userAgent = window.navigator.userAgent.toLowerCase();
+          const platform = window.navigator.platform.toLowerCase();
+
+          if (userAgent.indexOf("win") > -1) return "Windows";
+          if (userAgent.indexOf("mac") > -1) return "MacOS";
+          if (userAgent.indexOf("linux") > -1) return "Linux";
+
+          return "Unknown OS";
+        }
+
+        fetch(`http://127.0.0.1:8081/api/v1/events/video-metadata/stream/${videoId}/`)
+          .then((response) => {
+            if (response.status === 429) {
+              return response.json().then((responseData) => {
+                console.log(
+                  "Rate limit exceeded. Please wait before making another request."
+                );
+                console.log(`Wait time: ${responseData.data.wait_time}`);
+              });
+            } else if (!response.ok) {
+              throw new Error("Network response was not ok.");
+            }
+            return response.json();
+          })
+          .then((responseData) => {
+            if (responseData.data.status === "success") {
+              const data = responseData.data.data;
+              const os = getOS();
+              let url;
+
+              if (os === "Windows") {
+                url = data.mp4_gcore_cdn_mpd_url;
+              } else if (os === "MacOS" || os === "Linux") {
+                url = data.mov_gcore_cdn_mpd_url;
+              } else {
+                url = data.mp4_gcore_cdn_mpd_url;
+              }
+
+              // Example CDN (Gcore) URL for MP4 container.
+              //url = `https://cdn.algocode.site/vod-media/15a2fcd3-c8dd-4519-b2c2-ce8a975f2c04__rain-bg-vid/mov/manifest.mpd`
+              console.log("CDN URL: ", url);
+              console.log("Client OS: ", os);
+
+              const player = dashjs.MediaPlayer().create();
+              player.initialize(
+                document.querySelector("#videoPlayer"),
+                url,
+                true
+              );
+
+              player.on("error", function (e) {
+                console.error("DASH player error:", e);
+              });
+
+              document.getElementById("videoTitle").textContent = data.title;
+              document.getElementById("videoDescription").textContent =
+                data.description;
+            } else {
+              console.error("Error in API response:", responseData.data.status);
+            }
+          })
+          .catch((error) => {
+            console.error("Error fetching video metadata:", error);
+          });
+      });
+    </script>
+  </body>
+</html>

--- a/src/html-templates/dash-plyaer.html
+++ b/src/html-templates/dash-plyaer.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Movio Player</title>
+    <script src="https://cdn.dashjs.org/latest/dash.all.min.js"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@300;400;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <style>
+        body {
+            font-family: 'Nunito Sans', sans-serif;
+            background-color: #d9dfe4;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .header {
+            width: 100%;
+            background-color: #16bdb4;
+            color: white;
+            padding: 10px 0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 10px 20px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .header .logo {
+            font-size: 24px;
+            font-weight: bold;
+        }
+        .header .menu {
+            display: flex;
+            gap: 15px;
+        }
+        .header .menu a {
+            color: white;
+            text-decoration: none;
+            font-size: 18px;
+        }
+        .header .menu a:hover {
+            text-decoration: underline;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 20px auto;
+            padding: 20px;
+            background-color: white;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+            width: 100%;
+            box-sizing: border-box;
+        }
+        .video-container {
+            position: relative;
+            padding-bottom: 56.25%; /* 16:9 aspect ratio */
+            height: 0;
+            overflow: hidden;
+        }
+        .video-container video {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+        }
+        .title {
+            font-size: 24px;
+            font-weight: bold;
+            margin: 10px 0;
+        }
+        .description {
+            font-size: 14px;
+            color: #606060;
+        }
+        .comments-section {
+            margin-top: 30px;
+        }
+        .comment {
+            margin-bottom: 20px;
+        }
+        .comment-author {
+            font-weight: bold;
+            margin-right: 5px;
+        }
+        .comment-text {
+            color: #333;
+        }
+        .add-comment {
+            margin-top: 20px;
+        }
+        .add-comment textarea {
+            width: 100%;
+            padding: 10px;
+            margin-bottom: 10px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            resize: vertical;
+        }
+        .add-comment button {
+            background-color: #16bdb4;
+            color: white;
+            padding: 10px 20px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        @media (max-width: 768px) {
+            .header .logo {
+                font-size: 20px;
+            }
+            .header .menu a {
+                font-size: 16px;
+            }
+            .title {
+                font-size: 20px;
+            }
+            .description {
+                font-size: 12px;
+            }
+        }
+        @media (max-width: 480px) {
+            .header {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+            .header .menu {
+                flex-direction: column;
+                gap: 10px;
+                align-items: flex-start;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <div class="logo"><i class="fas fa-play-circle"></i> Movio Player</div>
+        <div class="menu">
+            <a href="#"><i class="fas fa-home"></i> Home</a>
+            <a href="#"><i class="fas fa-video"></i> Videos</a>
+            <a href="#"><i class="fas fa-user"></i> Profile</a>
+        </div>
+    </div>
+    <div class="container">
+        <div class="video-container">
+            <video id="videoPlayer" controls></video>
+        </div>
+        <div class="title">Popeyen   The President</div>
+        <div class="description">Nostalgia Vintage Popeye Cartoon :p</div>
+        <div class="comments-section">
+            <div class="comment">
+                <span class="comment-author">Yurious:</span>
+                <span class="comment-text">I love popeye cartoon man! Thanks for sharing.</span>
+            </div>
+            <div class="comment">
+                <span class="comment-author">Mehboob:</span>
+                <span class="comment-text">Very nostalgic, upload more such video!</span>
+            </div>
+            <div class="comment">
+                <span class="comment-author">Angel Priya:</span>
+                <span class="comment-text">Really very good animation! Old is Gold!</span>
+            </div>
+            <div class="add-comment">
+                <textarea placeholder="Add a public comment..."></textarea>
+                <button type="button">Comment</button>
+            </div>
+        </div>
+    </div>
+    <script>
+        document.addEventListener("DOMContentLoaded", function () {
+
+
+            const videoId = "6f214f93-f682-4024-b2dd-9f81f69a03a6";
+
+            // popey president video
+            url = "https://movio-cdn.algocode.site/segments/aaab9653-c84f-45f4-b94a-c6c4e7669670__test2/manifest.mpd";
+            const player = dashjs.MediaPlayer().create();
+            player.initialize(document.querySelector("#videoPlayer"), url, true);
+
+            player.on("error", function (e) {
+                console.error("DASH player error:", e);
+            });
+
+            player.on("initialized", function () {
+                console.log("DASH player initialized.");
+            });
+
+            player.on("streaming:bufferingCompleted", function () {
+                console.log("Buffering completed.");
+            });
+
+            player.on("manifestLoaded", function (e) {
+                console.log("Manifest loaded.");
+                const manifest = e.manifest;
+
+                if (manifest && manifest.Periods) {
+                    manifest.Periods.forEach(period => {
+                        period.AdaptationSets.forEach(adaptationSet => {
+                            if (adaptationSet.mimeType.startsWith('text/')) {
+                                console.log("Subtitle track found:", adaptationSet);
+                                adaptationSet.Representations.forEach(rep => {
+                                    console.log("Subtitle Representation:", rep);
+                                });
+                                player.setTextDefaultLanguage(adaptationSet.lang);
+                            }
+                        });
+                    });
+                }
+            });
+
+
+        });
+    </script>
+</body>
+</html>

--- a/src/html-templates/demo-code.js
+++ b/src/html-templates/demo-code.js
@@ -1,0 +1,55 @@
+
+                const videoId = "6f214f93-f682-4024-b2dd-9f81f69a03a6";
+                const url = "https://movio-cdn.algocode.site/segments/aaab9653-c84f-45f4-b94a-c6c4e7669670__test2/manifest.mpd";
+
+                const player = dashjs.MediaPlayer().create();
+                player.initialize(document.querySelector("#videoPlayer"), url, true);
+
+                player.on("error", function (e) {
+                        console.error("DASH player error:", e);
+                });
+
+                player.on("initialized", function () {
+                        console.log("DASH player initialized.");
+                });
+
+                player.on("streaming:bufferingCompleted", function () {
+                        console.log("Buffering completed.");
+                });
+
+                player.on("streamInitialized", function () {
+                        const availableTracks = player.getTracksFor('text');
+                        console.log("Available subtitle tracks:", availableTracks);
+
+                        availableTracks.forEach(track => {
+                                player.setTextTrack(track.index);
+                                console.log(`Enabled subtitle track: ${track.lang}`);
+                        });
+
+                        createSubtitleUI(availableTracks);
+                });
+
+                function createSubtitleUI(tracks) {
+                        const container = document.createElement('div');
+                        container.id = 'subtitleSelector';
+
+                        const select = document.createElement('select');
+                        select.addEventListener('change', (e) => {
+                                player.setTextTrack(parseInt(e.target.value));
+                        });
+
+                        const noneOption = document.createElement('option');
+                        noneOption.value = -1;
+                        noneOption.textContent = 'No subtitles';
+                        select.appendChild(noneOption);
+
+                        tracks.forEach((track, index) => {
+                                const option = document.createElement('option');
+                                option.value = index;
+                                option.textContent = `Subtitles: ${track.lang}`;
+                                select.appendChild(option);
+                        });
+
+                        container.appendChild(select);
+                        document.body.appendChild(container);
+                }

--- a/src/html-templates/shaka-player.html
+++ b/src/html-templates/shaka-player.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+        <title>Movio Player</title>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/shaka-player/3.2.4/shaka-player.compiled.js"></script>
+        <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@300;400;600;700&display=swap"
+                rel="stylesheet">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+        <style>
+        body {
+            font-family: 'Nunito Sans', sans-serif;
+            background-color: #d9dfe4;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .header {
+            width: 100%;
+            background-color: #16bdb4;
+            color: white;
+            padding: 10px 0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 10px 20px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .header .logo {
+            font-size: 24px;
+            font-weight: bold;
+        }
+        .header .menu {
+            display: flex;
+            gap: 15px;
+        }
+        .header .menu a {
+            color: white;
+            text-decoration: none;
+            font-size: 18px;
+        }
+        .header .menu a:hover {
+            text-decoration: underline;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 20px auto;
+            padding: 20px;
+            background-color: white;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+            width: 100%;
+            box-sizing: border-box;
+        }
+        .video-container {
+            position: relative;
+            padding-bottom: 56.25%; /* 16:9 aspect ratio */
+            height: 0;
+            overflow: hidden;
+        }
+        .video-container video {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+        }
+        .title {
+            font-size: 24px;
+            font-weight: bold;
+            margin: 10px 0;
+        }
+        .description {
+            font-size: 14px;
+            color: #606060;
+        }
+        .comments-section {
+            margin-top: 30px;
+        }
+        .comment {
+            margin-bottom: 20px;
+        }
+        .comment-author {
+            font-weight: bold;
+            margin-right: 5px;
+        }
+        .comment-text {
+            color: #333;
+        }
+        .add-comment {
+            margin-top: 20px;
+        }
+        .add-comment textarea {
+            width: 100%;
+            padding: 10px;
+            margin-bottom: 10px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            resize: vertical;
+        }
+        .add-comment button {
+            background-color: #16bdb4;
+            color: white;
+            padding: 10px 20px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        @media (max-width: 768px) {
+            .header .logo {
+                font-size: 20px;
+            }
+            .header .menu a {
+                font-size: 16px;
+            }
+            .title {
+                font-size: 20px;
+            }
+            .description {
+                font-size: 12px;
+            }
+        }
+        @media (max-width: 480px) {
+            .header {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+            .header .menu {
+                flex-direction: column;
+                gap: 10px;
+                align-items: flex-start;
+            }
+        }
+</style>
+</head>
+
+<body>
+        <div class="header">
+                <div class="logo"><i class="fas fa-play-circle"></i> Movio Player</div>
+                <div class="menu">
+                        <a href="#"><i class="fas fa-home"></i> Home</a>
+                        <a href="#"><i class="fas fa-video"></i> Videos</a>
+                        <a href="#"><i class="fas fa-user"></i> Profile</a>
+                </div>
+        </div>
+        <div class="container">
+                <div class="video-container">
+                        <video id="videoPlayer" controls></video>
+                </div>
+                <div class="title">Popey The President</div>
+                <div class="description">Nostalgia Vintage Popey Cartoon :p</div>
+                <div class="comments-section">
+                        <div class="comment">
+                                <span class="comment-author">Yurious:</span>
+                                <span class="comment-text">I love popey cartoon man! Thanks for sharing.</span>
+                        </div>
+                        <div class="comment">
+                                <span class="comment-author">Mehboob:</span>
+                                <span class="comment-text">Very nostalgic, upload more such video!</span>
+                        </div>
+                        <div class="comment">
+                                <span class="comment-author">Angel Priya:</span>
+                                <span class="comment-text">Really very good animation! Old is Gold!</span>
+                        </div>
+                        <div class="add-comment">
+                                <textarea placeholder="Add a public comment..."></textarea>
+                                <button type="button">Comment</button>
+                        </div>
+                </div>
+        </div>
+        <script>
+                document.addEventListener("DOMContentLoaded", function () {
+                        const videoId = "6f214f93-f682-4024-b2dd-9f81f69a03a6";
+                        const url = "http://movio-cdn.algocode.site/segments/aaab9653-c84f-45f4-b94a-c6c4e7669670__test2/manifest.mpd";
+                        const player = new shaka.Player(document.querySelector("#videoPlayer"));
+
+                        player.addEventListener('error', (event) => {
+                                console.error("Shaka Player error:", event.detail);
+                        });
+
+                        player.load(url).then(() => {
+                                console.log("Shaka Player initialized and manifest loaded.");
+                        }).catch((e) => {
+                                console.error("Error loading manifest:", e);
+                        });
+
+                        player.configure({
+                                textDisplayFactory: () => new shaka.text.SimpleTextDisplayer(document.querySelector("#videoPlayer")),
+                        });
+
+                        player.addEventListener('manifestloaded', (event) => {
+                                console.log("Manifest loaded.");
+                                const tracks = player.getTextTracks();
+                                tracks.forEach(track => {
+                                        if (track.kind === 'subtitle') {
+                                                console.log("Subtitle track found:", track);
+                                                console.log("Subtitle Track ID:", track.id);
+                                        }
+                                });
+                        });
+                });
+        </script>
+</body>
+
+</html>

--- a/src/movio_api_service/settings/base.py
+++ b/src/movio_api_service/settings/base.py
@@ -132,3 +132,6 @@ USE_TZ = True
 # SITE_ID = 1
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+
+

--- a/src/movio_api_service/settings/dev.py
+++ b/src/movio_api_service/settings/dev.py
@@ -55,7 +55,21 @@ AWS_S3_CUSTOM_DOMAIN = f"{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com"
 
 # MEDIA_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/"
 
-########################################################
+# S3 Bucket for Segments and processed subtitles: segments and subtitles directory
+AWS_MOVIO_S3_SEGMENTS_SUBTITLES_BUCKET_NAME = env(
+    "AWS_MOVIO_S3_SEGMENTS_SUBTITLES_BUCKET_NAME"
+)
+
+# Root of video segments in S3
+AWS_MOVIO_S3_SEGMENTS_BUCKET_ROOT = "segments"
+
+# Root of video subtitles in S3
+AWS_MOVIO_S3_SUBTITLES_BUCKET_ROOT = "subtitles"
+
+
+# ############################ Gcore CDN URL
+
+GCORE_CDN_URL_BASE = env("GCORE_CDN_URL_BASE")
 
 # ########################## Static and Media
 
@@ -95,7 +109,7 @@ VIDEO_UPLOAD_API = "/api/v1/app/events/video-upload/"
 
 MAX_VIDEO_FILE_SIZE = 100 * 1024 * 1024  # 100MB
 
-ALLOWED_VIDEO_FILE_FORMATS = ["video/mp4", "video/quicktime", "video/x-matroska"]  # mp4, mov, mkv
+ALLOWED_VIDEO_FILE_FORMATS = ["video/x-matroska"]  # .mkv only .mkv is supported for beta version of Movio
 
 # ########################## RabbitMQ Config
 


### PR DESCRIPTION
### API to serve VideoMetaData for Video On Demand Streaming through CDN 

* detail: `api/v1/app/stream/video/<uuid:video_id>/` to serve the Gcore CDN Endpoint as the segments are served thourgh the CDN as S3 as Upstream of the CDN